### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/0bvim/octoBuddy/security/code-scanning/1](https://github.com/0bvim/octoBuddy/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the permissions required. Since the workflow only checks out code and runs tests, it only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
