### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,8 @@
 name: Build Check
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: ["Lint check"]


### PR DESCRIPTION
Potential fix for [https://github.com/0bvim/octoBuddy/security/code-scanning/2](https://github.com/0bvim/octoBuddy/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only checks out the code and builds it, it only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the least privileges necessary to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
